### PR TITLE
Get simple tests working

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,1 @@
+# Toit Package.

--- a/src/three_color.toit
+++ b/src/three_color.toit
@@ -7,7 +7,7 @@
 // A texture is an object that can draw itself onto a canvas.
 
 import font show Font
-import icons shot Icon
+import icons show Icon
 import .texture
 import .two_bit_texture
 

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,0 +1,5 @@
+prefixes:
+  pixel_display: ..
+packages:
+  ..:
+    path: ..

--- a/tests/simple.toit
+++ b/tests/simple.toit
@@ -1,0 +1,55 @@
+// Copyright (C) 2021 Toitware ApS.  All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import expect show *
+import font show Font
+import pixel_display show *
+import two_color
+
+class TwoColorDriver extends AbstractDriver:
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_2_COLOR
+  draw_two_color x/int y/int w/int h/int pixels/ByteArray -> none:
+
+class ThreeColorDriver extends AbstractDriver:
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_3_COLOR
+  draw_two_bit x/int y/int w/int h/int plane0/ByteArray plane1/ByteArray -> none:
+
+class FourGrayDriver extends AbstractDriver:
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_4_COLOR
+  draw_two_bit x/int y/int w/int h/int plane0/ByteArray plane1/ByteArray -> none:
+
+class TrueColorDriver extends AbstractDriver:
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_TRUE_COLOR
+  draw_true_color x/int y/int w/int h/int r/ByteArray g/ByteArray b/ByteArray -> none:
+
+main:
+  driver2 := TwoColorDriver
+  display2 := TwoColorPixelDisplay driver2
+  
+  driver3 := ThreeColorDriver
+  display3 := ThreeColorPixelDisplay driver3
+
+  driver4 := FourGrayDriver
+  display4 := FourGrayPixelDisplay driver4
+
+  driver_true := TrueColorDriver
+  display_true := TrueColorPixelDisplay driver_true
+
+  sans10 := Font.get "sans10"
+
+  [display2, display3, display4, display_true].do: | display |
+    ctx := display.context --landscape --font=sans10
+    display.filled_rectangle ctx 10 20 30 40
+    display.text ctx 50 20 "Testing"
+    display.text ctx 50 40 "the display"
+    display.text ctx 50 60 "for the win"
+    display.draw

--- a/tests/true_color.toit
+++ b/tests/true_color.toit
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Toitware ApS.  All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import expect show *
+import font show Font
+import pixel_display show *
+import true_color show *
+
+class TestDriver extends AbstractDriver:
+  buffer := ByteArray 3 * 64 * 128
+
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_TRUE_COLOR
+  draw_true_color x/int y/int w/int h/int r/ByteArray g/ByteArray b/ByteArray -> none:
+    h.repeat: | iy |
+      w.repeat: | ix |
+        buffer[0 + 3 * (x + ix + (y + iy) * width)] = r[ix + iy * w]
+        buffer[1 + 3 * (x + ix + (y + iy) * width)] = g[ix + iy * w]
+        buffer[2 + 3 * (x + ix + (y + iy) * width)] = b[ix + iy * w]
+
+  red_at x y:
+    return buffer[0 + 3 * (x + y * width)]
+
+  green_at x y:
+    return buffer[1 + 3 * (x + y * width)]
+
+  blue_at x y:
+    return buffer[2 + 3 * (x + y * width)]
+
+main:
+  driver := TestDriver
+  display := TrueColorPixelDisplay driver
+  display.background = get_rgb 0 1 2
+  
+  sans10 := Font.get "sans10"
+
+  ctx := display.context --landscape --color=(get_rgb 255 120 0) --font=sans10
+
+  display.filled_rectangle ctx 10 20 30 40
+  display.text ctx 50 20 "Testing"
+  display.text ctx 50 40 "the display"
+  display.text ctx 50 60 "for the win"
+
+  display.draw
+
+  driver.height.repeat: | y |
+    line := ""
+    driver.width.repeat: | x |
+      line += "$((driver.red_at x y) < 128 ? " " : "*")"
+    print line
+      
+  50.repeat: | x |
+    driver.height.repeat: | y |
+      if x < 10 or y < 20 or x >= 40 or y >= 60:
+        expect_equals 0 (driver.red_at x y)
+        expect_equals 1 (driver.green_at x y)
+        expect_equals 2 (driver.blue_at x y)
+      else:
+        expect_equals 255 (driver.red_at x y)
+        expect_equals 120 (driver.green_at x y)
+        expect_equals 0 (driver.blue_at x y)


### PR DESCRIPTION
Tears out the RPC support and adds an AbstractDriver
class that can be used to make user-space pixel displays.