### PR TITLE
Add gray-scale display.

### DIFF
--- a/src/four_gray.toit
+++ b/src/four_gray.toit
@@ -139,6 +139,57 @@ class SimpleWindow extends TwoBitSimpleWindow_:
   constructor x/int y/int w/int h/int transform/Transform border_width/int border_color/int background_color/int:
     super x y w h transform border_width border_color background_color
 
-class RoundedCornerWindow extends TwoBitRoundedCornerWindow_:
-  constructor x/int y/int w/int h/int transform/Transform corner_radius/int background_color/int:
-    super x y w h transform corner_radius background_color
+class RoundedCornerWindow extends RoundedCornerWindow_:
+  background_color := ?
+
+  constructor x y w h transform corner_radius .background_color:
+    super x y w h transform corner_radius
+
+  make_alpha_map_ canvas padding:
+    return ByteArray (canvas.width + padding) * (canvas.height + padding)
+
+  make_opaque_ x y w h map map_width --frame/bool:
+    assert: not frame
+    bytemap_rectangle x y 0xff w h map map_width
+
+  set_opacity_ x y opacity map map_width --frame/bool:
+    assert: not frame
+    if 0 <= x < map_width:
+      y_offset := y * map_width
+      if 0 <= y_offset < map.size:
+        map[x + y_offset] = opacity
+
+  draw_background win_x win_y canvas:
+    bytemap_zap canvas.pixels_ background_color
+
+  draw_frame win_x win_y canvas:
+    throw "UNREACHABLE"
+
+class DropShadowWindow extends DropShadowWindow_:
+  background_color := ?
+  max_shadow_opacity_ := ?
+
+  constructor x y w h transform .background_color --corner_radius=5 --blur_radius=5 --drop_distance_x=10 --drop_distance_y=10 --shadow_opacity_percent=25:
+    max_shadow_opacity_ = (shadow_opacity_percent * 2.5500001).to_int
+    super x y w h transform corner_radius blur_radius drop_distance_x drop_distance_y
+
+  make_alpha_map_ canvas padding:
+    return ByteArray (canvas.width + padding) * (canvas.height + padding)
+
+  make_opaque_ x y w h map map_width --frame/bool:
+    bytemap_rectangle x y (frame ? max_shadow_opacity_ : 255) w h map map_width
+
+  set_opacity_ x y opacity map map_width --frame/bool:
+    if 0 <= x < map_width:
+      y_offset := y * map_width
+      if 0 <= y_offset < map.size:
+        if frame:
+          map[x + y_offset] = (opacity * max_shadow_opacity_) >> 8
+        else:
+          map[x + y_offset] = opacity
+
+  draw_background win_x win_y canvas:
+    bytemap_zap canvas.pixels_ background_color
+
+  draw_frame win_x win_y canvas:
+    bytemap_zap canvas.pixels_ 0

--- a/src/four_gray.toit
+++ b/src/four_gray.toit
@@ -62,16 +62,22 @@ class IconTexture extends TwoBitTextTexture_:
     text = new_icon.stringify
     font = new_icon.font_
 
-/// A texture that contains an uncompressed 2-color image.
-/// Initially all pixels are transparent, but pixels can be given the color
-///   with $set_pixel.
+/**
+A texture that contains an uncompressed 2-color image.
+Initially all pixels are transparent, but pixels can be given the color
+  with $set_pixel.
+*/
 class BitmapTexture extends TwoBitBitmapTexture_:
   constructor x/int y/int w/int h/int transform/Transform color/int:
     super x y w h transform color
 
-/// A two color bitmap texture.  Initially all pixels have the background color.
-/// Use $set_pixel to paint with the foreground, and $clear_pixel to paint with
-///   the background.
+/**
+A two color bitmap texture where foreground and background pixels in the
+  texture are both drawn.
+Initially all pixels have the background color.
+Use $set_pixel to paint with the foreground, and $clear_pixel to paint with
+  the background.
+*/
 class OpaqueBitmapTexture extends TwoBitOpaqueBitmapTexture_:
 
   constructor x/int y/int w/int h/int transform/Transform foreground_color/int background_color:
@@ -131,11 +137,11 @@ class BarCodeEan13 extends TwoBitBarCodeEan13_:
   constructor code/string x/int y/int transform/Transform:
     super code x y transform BLACK WHITE
 
+/**
+A rectangular window with a fixed width colored border.
+The border is subtracted from the visible area inside the window.
+*/
 class SimpleWindow extends TwoBitSimpleWindow_:
-  /**
-  A rectangular window with a fixed width colored border.  The border is
-    subtracted from the visible area inside the window.
-  */
   constructor x/int y/int w/int h/int transform/Transform border_width/int border_color/int background_color/int:
     super x y w h transform border_width border_color background_color
 
@@ -170,6 +176,8 @@ class DropShadowWindow extends DropShadowWindow_:
   max_shadow_opacity_ := ?
 
   constructor x y w h transform .background_color --corner_radius=5 --blur_radius=5 --drop_distance_x=10 --drop_distance_y=10 --shadow_opacity_percent=25:
+    // Scale the 0-100% opacity percentage to cover the 8 bit unsigned integer
+    // range 0-255.
     max_shadow_opacity_ = (shadow_opacity_percent * 2.5500001).to_int
     super x y w h transform corner_radius blur_radius drop_distance_x drop_distance_y
 

--- a/src/gray_scale.toit
+++ b/src/gray_scale.toit
@@ -41,8 +41,8 @@ class Canvas:
     return pixels_[x + width * y]
 
   /**
-   * Creates an blank texture with the same dimensions as this one.
-   */
+  Creates a blank texture with the same dimensions as this one.
+  */
   create_similar:
     return Canvas width height
 
@@ -70,7 +70,7 @@ class FilledRectangle extends FilledRectangle_:
     assert: 0 <= color_ <= 0xff
     super x y w h transform
 
-  /// A line from x1,y1 to x2,y2.  The line must be horizontal or vertical.
+  /// A line from $x1,$y1 to $x2,$y2.  The line must be horizontal or vertical.
   constructor.line color x1/int y1/int x2/int y2/int transform/Transform:
     return FilledRectangle_.line_ x1 y1 x2 y2: | x y w h |
       FilledRectangle color x y w h transform
@@ -111,8 +111,10 @@ class IconTexture extends TextTexture:
     text = new_icon.stringify
     font = new_icon.font_
 
-// A texture that contains an uncompressed 2-color image.  Initially all pixels
-// are transparent, but pixels can be given the color with $set_pixel.
+/**
+A texture that contains an uncompressed 2-color image.  Initially all pixels
+  are transparent, but pixels can be given the color with $set_pixel.
+*/
 class BitmapTexture extends BitmapTexture_:
   color_ := 0
 
@@ -122,9 +124,13 @@ class BitmapTexture extends BitmapTexture_:
   draw_ bx by orientation canvas:
     bitmap_draw_bitmap bx by color_ orientation bytes_ 0 w canvas.pixels_ canvas.width true
 
-// A two color bitmap texture.  Initially all pixels have the background color.
-// Use set_pixel to paint with the foreground, and clear_pixel to paint with
-// the background.
+/**
+A two color bitmap texture where foreground and background pixels in the
+  texture are both drawn.
+Initially all pixels have the background color.
+Use $set_pixel to paint with the foreground, and $clear_pixel to paint with
+  the background.
+*/
 class OpaqueBitmapTexture extends BitmapTexture:
   background_color_ := 0
 
@@ -155,14 +161,14 @@ class BarCodeEan13 extends BarCodeEan13_:
     black ::= 0
     bytemap_rectangle x y black width height canvas.pixels_ canvas.width
 
+/**
+A rectangular window with a fixed width colored border.
+The border is subtracted from the visible area inside the window.
+*/
 class SimpleWindow extends SimpleWindow_:
   background_color := ?
   border_color := ?
 
-  /**
-   * A rectangular window with a fixed width colored border.  The border is
-   * subtracted from the visible area inside the window.
-   */
   constructor x y w h transform border_width .border_color .background_color:
     super x y w h transform border_width
 
@@ -209,6 +215,8 @@ class DropShadowWindow extends DropShadowWindow_:
   max_shadow_opacity_ := ?
 
   constructor x y w h transform .background_color --corner_radius=5 --blur_radius=5 --drop_distance_x=10 --drop_distance_y=10 --shadow_opacity_percent=25:
+    // Scale the 0-100% opacity percentage to cover the 8 bit unsigned integer
+    // range 0-255.
     max_shadow_opacity_ = (shadow_opacity_percent * 2.5500001).to_int
     super x y w h transform corner_radius blur_radius drop_distance_x drop_distance_y
 

--- a/src/texture.toit
+++ b/src/texture.toit
@@ -777,7 +777,7 @@ abstract class WindowTexture_ extends ResizableTexture:
     a bytemap with 0 for transparent and 0xff for opaque.  As a special case it
     may return a single-entry byte array, which means all pixels have the same
     transparency.
-   */
+  */
   abstract painting_map win_x/int win_y/int canvas -> ByteArray
 
   /**

--- a/src/texture.toit
+++ b/src/texture.toit
@@ -762,10 +762,10 @@ abstract class WindowTexture_ extends ResizableTexture:
   Returns a canvas that is an alpha map for the given area that describes where
     the wall around this window shines through.  This defines the edges and
     shadows of a window frame.  For 2-color and 3-color textures this is a
-    bitmap with 0 for transparent and 1 for opaque.  For true-color textures it
-    is a bytemap with 0 for transparent and 0xff for opaque.  As a special case
-    it may return a single-entry byte array, which means all pixels have the same
-    transparency.
+    bitmap with 0 for transparent and 1 for opaque.  For true-color and
+    gray-scale textures it is a bytemap with 0 for transparent and 0xff for
+    opaque.  As a special case it may return a single-entry byte array, which
+    means all pixels have the same transparency.
   */
   abstract frame_map win_x/int win_y/int canvas -> ByteArray
 
@@ -773,9 +773,10 @@ abstract class WindowTexture_ extends ResizableTexture:
   Returns a canvas that is an alpha map for the given area that describes where
     the painting is visible.  This defines the edges of the content of this
     window.  For 2-color and 3-color textures this is a bitmap with 0 for
-    transparent and 1 for opaque.  For true-color textures it is a bytemap with
-    0 for transparent and 0xff for opaque.  As a special case it may return a
-    single-entry byte array, which means all pixels have the same transparency.
+    transparent and 1 for opaque.  For true-color and gray-scale textures it is
+    a bytemap with 0 for transparent and 0xff for opaque.  As a special case it
+    may return a single-entry byte array, which means all pixels have the same
+    transparency.
    */
   abstract painting_map win_x/int win_y/int canvas -> ByteArray
 

--- a/src/three_color.toit
+++ b/src/three_color.toit
@@ -36,7 +36,7 @@ class FilledRectangle extends TwoBitFilledRectangle_:
     assert: color != 3   // Invalid color.
     super color x y w h transform
 
-  /// A line from x1,y1 to x2,y2.  The line must be horizontal or vertical.
+  /// A line from $x1,$y1 to $x2,$y2.  The line must be horizontal or vertical.
   constructor.line color x1/int y1/int x2/int y2/int transform/Transform:
     return FilledRectangle_.line_ x1 y1 x2 y2: | x y w h |
       FilledRectangle color x y w h transform
@@ -64,8 +64,10 @@ class IconTexture extends TextTexture:
     text = new_icon.stringify
     font = new_icon.font_
 
-// A texture that contains an uncompressed 2-color image.  Initially all pixels
-// are transparent, but pixels can be given the color with $set_pixel.
+/**
+A texture that contains an uncompressed 2-color image.  Initially all pixels
+  are transparent, but pixels can be given the color with $set_pixel.
+*/
 class BitmapTexture extends TwoBitBitmapTexture_:
   constructor x/int y/int w/int h/int transform/Transform color/int:
     assert: color != 3   // Invalid color.
@@ -83,11 +85,11 @@ class BarCodeEan13 extends TwoBitBarCodeEan13_:
   constructor code/string x/int y/int transform/Transform:
     super code x y transform BLACK WHITE
 
+/**
+A rectangular window with a fixed width colored border.
+The border is subtracted from the visible area inside the window.
+*/
 class SimpleWindow extends TwoBitSimpleWindow_:
-  /**
-   * A rectangular window with a fixed width colored border.  The border is
-   * subtracted from the visible area inside the window.
-   */
   constructor x y w h transform border_width border_color background_color:
     super x y w h transform border_width border_color background_color
 

--- a/src/true_color.toit
+++ b/src/true_color.toit
@@ -61,8 +61,8 @@ class Canvas:
     return get_rgb red_[idx] green_[idx] blue_[idx]
 
   /**
-   * Creates an blank texture with the same dimensions as this one.
-   */
+  Creates a blank texture with the same dimensions as this one.
+  */
   create_similar:
     return Canvas width height
 
@@ -94,7 +94,7 @@ class FilledRectangle extends FilledRectangle_:
     assert: color_ <= 0xff_ff_ff  // Not transparent.
     super x y w h transform
 
-  /// A line from x1,y1 to x2,y2.  The line must be horizontal or vertical.
+  /// A line from $x1,$y1 to $x2,$y2.  The line must be horizontal or vertical.
   constructor.line color x1/int y1/int x2/int y2/int transform/Transform:
     return FilledRectangle_.line_ x1 y1 x2 y2: | x y w h |
       FilledRectangle color x y w h transform
@@ -139,8 +139,10 @@ class IconTexture extends TextTexture:
     text = new_icon.stringify
     font = new_icon.font_
 
-// A texture that contains an uncompressed 2-color image.  Initially all pixels
-// are transparent, but pixels can be given the color with $set_pixel.
+/**
+A texture that contains an uncompressed 2-color image.  Initially all pixels
+  are transparent, but pixels can be given the color with $set_pixel.
+*/
 class BitmapTexture extends BitmapTexture_:
   color_ := 0
 
@@ -152,9 +154,13 @@ class BitmapTexture extends BitmapTexture_:
     bitmap_draw_bitmap bx by (green_component color_) orientation bytes_ 0 w canvas.green_ canvas.width true
     bitmap_draw_bitmap bx by (blue_component color_) orientation bytes_ 0 w canvas.blue_ canvas.width true
 
-// A two color bitmap texture.  Initially all pixels have the background color.
-// Use set_pixel to paint with the foreground, and clear_pixel to paint with
-// the background.
+/**
+A two color bitmap texture where foreground and background pixels in the
+  texture are both drawn.
+Initially all pixels have the background color.
+Use $set_pixel to paint with the foreground, and $clear_pixel to paint with
+  the background.
+*/
 class OpaqueBitmapTexture extends BitmapTexture:
   background_color_ := 0
 
@@ -193,14 +199,14 @@ class BarCodeEan13 extends BarCodeEan13_:
        bytemap_rectangle x y black width height canvas.green_ canvas.width
        bytemap_rectangle x y black width height canvas.blue_  canvas.width
 
+/**
+A rectangular window with a fixed width colored border.
+The border is subtracted from the visible area inside the window.
+*/
 class SimpleWindow extends SimpleWindow_:
   background_color := ?
   border_color := ?
 
-  /**
-   * A rectangular window with a fixed width colored border.  The border is
-   * subtracted from the visible area inside the window.
-   */
   constructor x y w h transform border_width .border_color .background_color:
     super x y w h transform border_width
 
@@ -253,6 +259,8 @@ class DropShadowWindow extends DropShadowWindow_:
   max_shadow_opacity_ := ?
 
   constructor x y w h transform .background_color --corner_radius=5 --blur_radius=5 --drop_distance_x=10 --drop_distance_y=10 --shadow_opacity_percent=25:
+    // Scale the 0-100% opacity percentage to cover the 8 bit unsigned integer
+    // range 0-255.
     max_shadow_opacity_ = (shadow_opacity_percent * 2.5500001).to_int
     super x y w h transform corner_radius blur_radius drop_distance_x drop_distance_y
 

--- a/src/two_bit_texture.toit
+++ b/src/two_bit_texture.toit
@@ -50,7 +50,7 @@ class TwoBitCanvas_:
     return bit0 + (bit1 << 1)
 
   /**
-  Creates an blank texture with the same dimensions as this one.
+  Creates a blank texture with the same dimensions as this one.
   */
   create_similar:
     return TwoBitCanvas_ width height
@@ -105,8 +105,10 @@ class TwoBitTextTexture_ extends TextTexture_:
     bitmap_draw_text bx by color_&1        orientation string_ font_ canvas.plane_0_ canvas.width
     bitmap_draw_text bx by (color_&2) >> 1 orientation string_ font_ canvas.plane_1_ canvas.width
 
-// A texture that contains an uncompressed 2-color image.  Initially all pixels
-// are transparent, but pixels can be given the color with $set_pixel.
+/**
+A texture that contains an uncompressed 2-color image.  Initially all pixels
+  are transparent, but pixels can be given the color with $set_pixel.
+*/
 class TwoBitBitmapTexture_ extends BitmapTexture_:
   color_ := 0
 
@@ -117,9 +119,13 @@ class TwoBitBitmapTexture_ extends BitmapTexture_:
     bitmap_draw_bitmap bx by (color_ & 1) orientation bytes_ 0 w canvas.plane_0_ canvas.width false
     bitmap_draw_bitmap bx by ((color_ & 2) >> 1) orientation bytes_ 0 w canvas.plane_1_ canvas.width false
 
-// A two color bitmap texture.  Initially all pixels have the background color.
-// Use set_pixel to paint with the foreground, and clear_pixel to paint with
-// the background.
+/**
+A two color bitmap texture where foreground and background pixels in the
+  texture are both drawn.
+Initially all pixels have the background color.
+Use $set_pixel to paint with the foreground, and $clear_pixel to paint with
+  the background.
+*/
 class TwoBitOpaqueBitmapTexture_ extends TwoBitBitmapTexture_:
   background_color_ := 0
 
@@ -154,14 +160,14 @@ class TwoBitBarCodeEan13_ extends BarCodeEan13_:
     bitmap_rectangle x y (plane_0_ & 1) width height canvas.plane_0_ canvas.width
     bitmap_rectangle x y ((plane_0_ & 2) >> 1) width height canvas.plane_1_ canvas.width
 
+/**
+A rectangular window with a fixed width colored border.
+The border is subtracted from the visible area inside the window.
+*/
 class TwoBitSimpleWindow_ extends SimpleWindow_:
   background_color := ?
   border_color := ?
 
-  /**
-   * A rectangular window with a fixed width colored border.  The border is
-   * subtracted from the visible area inside the window.
-   */
   constructor x y w h transform border_width .border_color .background_color:
     super x y w h transform border_width
 

--- a/src/two_color.toit
+++ b/src/two_color.toit
@@ -46,8 +46,8 @@ class Canvas:
     return (pixels_[idx] & bit) == 0 ? 0 : 1
 
   /**
-   * Creates an blank texture with the same dimensions as this one.
-   */
+  Creates a blank texture with the same dimensions as this one.
+  */
   create_similar:
     return Canvas width height
 
@@ -77,7 +77,7 @@ class FilledRectangle extends FilledRectangle_:
     assert: color_ < 2  // Not transparent.
     super x y w h transform
 
-  /// A line from x1,y1 to x2,y2.  The line must be horizontal or vertical.
+  /// A line from $x1,$y1 to $x2,$y2.  The line must be horizontal or vertical.
   constructor.line color x1/int y1/int x2/int y2/int transform/Transform:
     return FilledRectangle_.line_ x1 y1 x2 y2: | x y w h |
       FilledRectangle color x y w h transform
@@ -118,8 +118,10 @@ class IconTexture extends TextTexture:
     text = new_icon.stringify
     font = new_icon.font_
 
-// A texture that contains an uncompressed 2-color image.  Initially all pixels
-// are transparent, but pixels can be given the color with $set_pixel.
+/**
+A texture that contains an uncompressed 2-color image.  Initially all pixels
+  are transparent, but pixels can be given the color with $set_pixel.
+*/
 class BitmapTexture extends BitmapTexture_:
   color_ := 0
 
@@ -132,6 +134,9 @@ class BitmapTexture extends BitmapTexture_:
 /**
 A two color bitmap texture where foreground and background pixels in the
   texture are both drawn.
+Initially all pixels have the background color.
+Use $set_pixel to paint with the foreground, and $clear_pixel to paint with
+  the background.
 */
 class OpaqueBitmapTexture extends BitmapTexture:
   foreground_color_/int := ?
@@ -164,14 +169,14 @@ class BarCodeEan13 extends BarCodeEan13_:
     black ::= 1
     bitmap_rectangle x y black width height canvas.pixels_ canvas.width
 
+/**
+A rectangular window with a fixed width colored border.
+The border is subtracted from the visible area inside the window.
+*/
 class SimpleWindow extends SimpleWindow_:
   background_color/int := ?
   border_color/int := ?
 
-  /**
-   * A rectangular window with a fixed width colored border.  The border is
-   * subtracted from the visible area inside the window.
-   */
   constructor x/int y/int w/int h/int transform/Transform border_width/int .border_color .background_color:
     super x y w h transform border_width
 

--- a/tests/drop_shadow_test.toit
+++ b/tests/drop_shadow_test.toit
@@ -4,7 +4,8 @@
 
 import bitmap show *
 import pixel_display.texture show *
-import pixel_display.true_color show *
+import pixel_display.true_color
+import pixel_display.gray_scale
 
 main:
   error := catch:
@@ -16,13 +17,31 @@ main:
   else if error:
     throw error
 
-  canvas := Canvas 64 48
+  true_color_test
+  gray_scale_test
+
+true_color_test -> none:
+  canvas := true_color.Canvas 64 48
   tr := Transform.identity
-  window := DropShadowWindow 30 20 140 100 tr (get_rgb 255 255 153) --corner_radius=7 --blur_radius=4 --drop_distance_x=-10 --drop_distance_y=-10
-  canvas.set_all_pixels (get_rgb 23 200 230)
+  window := true_color.DropShadowWindow 30 20 140 100 tr (true_color.get_rgb 255 255 153) --corner_radius=7 --blur_radius=4 --drop_distance_x=-10 --drop_distance_y=-10
+  canvas.set_all_pixels (true_color.get_rgb 23 200 230)
   window.write 0 0 canvas
   48.repeat: | y |
     line := ""
     64.repeat: | x |
       pixel := canvas.get_pixel x y
-      line += "$(%3d red_component pixel) $(%3d green_component pixel) $(%3d blue_component pixel)   ";
+      line += "$(%3d true_color.red_component pixel) $(%3d true_color.green_component pixel) $(%3d true_color.blue_component pixel)   ";
+    print line
+
+gray_scale_test -> none:
+  canvas := gray_scale.Canvas 64 48
+  tr := Transform.identity
+  window := gray_scale.DropShadowWindow 30 20 140 100 tr gray_scale.DARK_GRAY --corner_radius=7 --blur_radius=4 --drop_distance_x=-10 --drop_distance_y=-10
+  canvas.set_all_pixels gray_scale.LIGHT_GRAY
+  window.write 0 0 canvas
+  48.repeat: | y |
+    line := ""
+    64.repeat: | x |
+      pixel := canvas.get_pixel x y
+      line += "$(%3d pixel) ";
+    print line

--- a/tests/gray_scale.toit
+++ b/tests/gray_scale.toit
@@ -1,0 +1,55 @@
+// Copyright (C) 2021 Toitware ApS.  All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import expect show *
+import font show Font
+import pixel_display show *
+import pixel_display.gray_scale show *
+
+class TestDriver extends AbstractDriver:
+  buffer := ByteArray 64 * 128
+
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_GRAY_SCALE | FLAG_PARTIAL_UPDATES
+  draw_gray_scale left/int top/int right/int bottom/int pixels/ByteArray -> none:
+    w := right - left
+    (bottom - top).repeat: | iy |
+      w.repeat: | ix |
+        buffer[left + ix + (top + iy) * width] = pixels[ix + iy * w]
+
+  pixel_at x y:
+    return buffer[x + y * width]
+
+main:
+  driver := TestDriver
+  display := GrayScalePixelDisplay driver
+  display.background = 1
+  
+  sans10 := Font.get "sans10"
+
+  ctx := display.context --landscape --color=250 --font=sans10
+
+  display.filled_rectangle ctx 10 20 30 40
+  display.text ctx 50 20 "Testing"
+  display.text ctx 50 40 "the display"
+  display.draw
+  display.text ctx 50 60 "for the win"
+
+  display.draw
+
+  for y := 0; y < driver.height; y += 2:
+    line := ""
+    driver.width.repeat: | x |
+      top_half := (driver.pixel_at x y) < 128
+      bottom_half := (driver.pixel_at x y + 1) < 128
+      line += "$(top_half ? (bottom_half ? " " : "▄") : (bottom_half ? "▀" : "█"))"
+    print line
+      
+  50.repeat: | x |
+    driver.height.repeat: | y |
+      if x < 10 or y < 20 or x >= 40 or y >= 60:
+        expect_equals 1 (driver.pixel_at x y)
+      else:
+        expect_equals 250 (driver.pixel_at x y)

--- a/tests/simple.toit
+++ b/tests/simple.toit
@@ -31,6 +31,12 @@ class TrueColorDriver extends AbstractDriver:
   flags ::= FLAG_TRUE_COLOR
   draw_true_color x/int y/int w/int h/int r/ByteArray g/ByteArray b/ByteArray -> none:
 
+class GrayScaleDriver extends AbstractDriver:
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_GRAY_SCALE
+  draw_gray_scale x/int y/int w/int h/int pixels/ByteArray -> none:
+
 main:
   driver2 := TwoColorDriver
   display2 := TwoColorPixelDisplay driver2
@@ -44,9 +50,12 @@ main:
   driver_true := TrueColorDriver
   display_true := TrueColorPixelDisplay driver_true
 
+  driver_gray := GrayScaleDriver
+  display_gray := GrayScalePixelDisplay driver_gray
+
   sans10 := Font.get "sans10"
 
-  [display2, display3, display4, display_true].do: | display |
+  [display2, display3, display4, display_true, display_gray].do: | display |
     ctx := display.context --landscape --font=sans10
     display.filled_rectangle ctx 10 20 30 40
     display.text ctx 50 20 "Testing"


### PR DESCRIPTION
This display type can be useful for the 16-shades
gray-scale e-paper displays.  It uses one byte per
pixel of gray-scale data.  All the primitives are
used unchanged from the true-color 24 bit display.
Almost all the code is a straight-forward copy of
the true-color code, reduced from three channels
to one.