### PR TITLE
Clean up and fix invalidation in windows.

### DIFF
--- a/src/histogram.toit
+++ b/src/histogram.toit
@@ -60,7 +60,7 @@ abstract class Histogram extends SizedTexture:
   write2_ win_x win_y canvas:
     List.chunk_up 0 fullness_ 16: | from to size |
       worth_plotting := false
-      get_transform.xywh (x + from) y size h_: | x2 y2 w2 h2 |
+      transform.xywh (x + from) y size h_: | x2 y2 w2 h2 |
         if w2 > 0 and h2 > 0 and x2 - win_x + w2 > 0 and x2 - win_x < canvas.width:
           worth_plotting = true
       if worth_plotting:
@@ -69,7 +69,7 @@ abstract class Histogram extends SizedTexture:
           coord := y + (sample_to_coordinate_ values_[hx])
           wy1 := coord
           wy2 := y + h_
-          get_transform.xywh wx wy1 1 (wy2 - wy1): | x2 y2 w2 h2 |
+          transform.xywh wx wy1 1 (wy2 - wy1): | x2 y2 w2 h2 |
             if w2 > 0 and h2 > 0:
               draw_rectangle
                 x2 - win_x

--- a/tests/simple.toit
+++ b/tests/simple.toit
@@ -6,47 +6,132 @@ import expect show *
 import font show Font
 import pixel_display show *
 import pixel_display.two_color
+import pixel_display.true_color
 
 class TwoColorDriver extends AbstractDriver:
   width ::= 128
   height ::= 64
   flags ::= FLAG_2_COLOR
-  draw_two_color x/int y/int w/int h/int pixels/ByteArray -> none:
+  draw_two_color left/int top/int right/int bottom/int pixels/ByteArray -> none:
 
 class ThreeColorDriver extends AbstractDriver:
   width ::= 128
   height ::= 64
   flags ::= FLAG_3_COLOR
-  draw_two_bit x/int y/int w/int h/int plane0/ByteArray plane1/ByteArray -> none:
+  draw_two_bit left/int top/int right/int bottom/int plane0/ByteArray plane1/ByteArray -> none:
 
 class FourGrayDriver extends AbstractDriver:
   width ::= 128
   height ::= 64
   flags ::= FLAG_4_COLOR
-  draw_two_bit x/int y/int w/int h/int plane0/ByteArray plane1/ByteArray -> none:
+  draw_two_bit left/int top/int right/int bottom/int plane0/ByteArray plane1/ByteArray -> none:
 
 class TrueColorDriver extends AbstractDriver:
   width ::= 128
   height ::= 64
   flags ::= FLAG_TRUE_COLOR
-  draw_true_color x/int y/int w/int h/int r/ByteArray g/ByteArray b/ByteArray -> none:
+  draw_true_color left/int top/int right/int bottom/int r/ByteArray g/ByteArray b/ByteArray -> none:
 
 class GrayScaleDriver extends AbstractDriver:
   width ::= 128
   height ::= 64
   flags ::= FLAG_GRAY_SCALE
-  draw_gray_scale x/int y/int w/int h/int pixels/ByteArray -> none:
+  draw_gray_scale left/int top/int right/int bottom/int pixels/ByteArray -> none:
 
 class SeveralColorDriver extends AbstractDriver:
   width ::= 128
   height ::= 64
   flags ::= FLAG_SEVERAL_COLOR
-  draw_several_color x/int y/int w/int h/int pixels/ByteArray -> none:
+  draw_several_color left/int top/int right/int bottom/int pixels/ByteArray -> none:
+
+class DrawRecordingDriver extends AbstractDriver:
+  width ::= 128
+  height ::= 64
+  flags ::= FLAG_TRUE_COLOR | FLAG_PARTIAL_UPDATES
+  r_left := 0
+  r_top := 0
+  r_right := 0
+  r_bottom := 0
+
+  constructor:
+    reset
+
+  reset -> none:
+    r_left = 1_000_000
+    r_top = 1_000_000
+    r_right = -1
+    r_bottom = -1
+
+  draw_true_color left/int top/int right/int bottom/int r/ByteArray g/ByteArray b/ByteArray -> none:
+    r_left = min r_left left
+    r_top = min r_top top
+    r_right = max r_right right
+    r_bottom = max r_bottom bottom
 
 main:
+  for_the_win_test
+  invalidate_test
+
+invalidate_test:
+  driver := DrawRecordingDriver
+  display := TrueColorPixelDisplay driver
+
+  context := display.context
+
+  display.draw
+  driver.reset
+
+  print "Rectangle"
+  display.filled_rectangle context 42 23 12 10
+  display.draw
+
+  expect_equals driver.r_left 40   // 42 rounded down.
+  expect_equals driver.r_right 56  // 42 + 12 rounded up.
+  expect_equals driver.r_top 16    // 23 rounded down.
+  expect_equals driver.r_bottom 40 // 23 + 10 rounded up.
+
+  driver.reset
+
+  print "Window"
+
+  window := true_color.SimpleWindow 42 23 22 20 context.transform
+      0  // Border width.
+      0  // Border color.
+      0  // Background color.
+
+  display.add window
+
+  display.draw
+
+  expect_equals driver.r_left 40   // 42 rounded down.
+  expect_equals driver.r_right 64  // 42 + 22 rounded up.
+  expect_equals driver.r_top 16    // 23 rounded down.
+  expect_equals driver.r_bottom 48 // 23 + 20 rounded up.
+
+  driver.reset
+
+  // Place rectangle at window-relative coordinates.
+  rect_in_window := true_color.FilledRectangle
+      0  // Color.
+      8  // x.
+      0  // y.
+      10 // w.
+      1  // h.
+      window.transform
+
+  window.add rect_in_window
+
+  display.draw
+
+  expect_equals driver.r_left 48   // 42 + 8 rounded down.
+  expect_equals driver.r_right 64  // 42 + 8 + 10 rounded up.
+  expect_equals driver.r_top 16    // 23 + 0 rounded down.
+  expect_equals driver.r_bottom 24 // 23 + 0 + 1 rounded up.
+
+for_the_win_test:
   driver2 := TwoColorDriver
   display2 := TwoColorPixelDisplay driver2
-  
+
   driver3 := ThreeColorDriver
   display3 := ThreeColorPixelDisplay driver3
 


### PR DESCRIPTION
For windows inside displays we were miscalculating
the driver coordinations for the invalidations that
control partial updates.  We did the transform
calculation twice, and didn't crop the updates from
textures inside the window.

A minor fix for partial updates of less than 8 pixel
heights (recently introduced for a very wide epaper
display).

Added test.