### PR TITLE
Make constant static.

### DIFF
--- a/src/texture.toit
+++ b/src/texture.toit
@@ -1263,7 +1263,8 @@ abstract class InfiniteBackground_ extends Texture:
   invalidate -> none:
 
 class PbmParser_:
-  INVALID_PBM_ ::= "INVALID PBM"
+  static INVALID_PBM_ ::= "INVALID PBM"
+
   bytes_ /ByteArray
   next_ := 0
 


### PR DESCRIPTION
The `INVALID_PBM_` was treated like a field.