### PR TITLE
Downgrade cmake version requirement.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a Zero-Clause BSD license that can
 # be found in the tests/TESTS_LICENSE file.
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.22)
 
 project(cli)
 


### PR DESCRIPTION
This version still works and is more available on diverse Linux distros.