### PR TITLE
Fix off-by-one in bounds of centered text.

### DIFF
--- a/src/texture.toit
+++ b/src/texture.toit
@@ -624,7 +624,7 @@ abstract class TextTexture_ extends SizedTexture:
         assert: alignment == TEXT_TEXTURE_ALIGN_CENTER
         assert: pixel_width_old == (font.pixel_width new)
         // Make x relative to the text origin, which is the middle.
-        unchanged_width := (pixel_width_old >> 1) - (font.pixel_width old[..unchanged_left])
+        unchanged_width := ((pixel_width_old + 1) >> 1) - (font.pixel_width old[..unchanged_left])
         changed_extent_old.x -= unchanged_width + changed_extent_old.displacement
         changed_extent_new.x -= unchanged_width + changed_extent_new.displacement
       block.call changed_extent_old changed_extent_new


### PR DESCRIPTION
The calculation of redraw boxes for centered text
was off by one because of confusion about rounding when the text has an odd pixel length.

Tests for this are in the version-2 branch.