### PR TITLE
Bump minimal Toit version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 env:
-  TOIT_VERSION: v2.0.0-alpha.144
+  TOIT_VERSION: v2.0.0-alpha.146
 
 jobs:
   build:

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name: pixel_display
 description: Common code to drive all pixel-based displays.
 environment:
-  sdk: ^2.0.0-alpha.144
+  sdk: ^2.0.0-alpha.146
 dependencies:
   png-tools:
     url: github.com/toitware/toit-png-tools


### PR DESCRIPTION
v2.0.0-alpha.144 and v2.0.0-alpha.145 were broken for this package.